### PR TITLE
Fixing too much celebration

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21837,7 +21837,7 @@ class MessageBuilder {
     }
 }
 const defaultRules = {
-    pr_reaches_power_of_10: true,
+    pr_reaches_contain_only_one_nonzero_digit: true,
     pr_reaches_power_of_2: true,
     pr_reaches_777: true,
     commit_hits_777: true,
@@ -21908,19 +21908,19 @@ function parseRules(json) {
 }
 exports.parseRules = parseRules;
 exports.Rules = {
-    pr_reaches_power_of_10: {
+    pr_reaches_contain_only_one_nonzero_digit: {
         kind: 'pr',
-        rule: /(?:[1]0+)/,
+        rule: /(?:^[1-9]0+$)/,
         message: `Now pull request issue number reaches **{{prNum}}**. It's time to celebrate!`,
     },
     pr_reaches_power_of_2: {
         kind: 'pr',
-        rule: /(?:(512|1024|2048|4096|8192|16384|32768|65536))/,
+        rule: /(?:^(512|1024|2048|4096|8192|16384|32768|65536)$)/,
         message: `Now pull request issue number reaches **{{prNum}}** (power of 2). It's time to celebrate!`,
     },
     pr_reaches_777: {
         kind: 'pr',
-        rule: /(?:7{3,})/,
+        rule: /(?:^7{3,}$)/,
         message: `Now pull request issue number reaches **{{prNum}}** (777). It's time to celebrate!`,
     },
     commit_hits_777: {

--- a/src/message_builder.spec.ts
+++ b/src/message_builder.spec.ts
@@ -28,4 +28,60 @@ describe('MessageBuilder', () => {
       ].join('\n'),
     });
   });
+
+  it('builds congratulatory message when inputs lucky pull request id', () => {
+    const context = {
+      commitIds: ['1243a86968b837366e6603cab1142462c8f33ea5'],
+      prNum: 777,
+    };
+    const mb = new CustomMessageBuilder(
+      `# :tada: Happy commit!\n{{#messages}}- {{&.}}\n{{/messages}}`,
+      {}
+    );
+    const message = mb.build(context);
+    expect(message).toEqual({
+      lucky: true,
+      body: [
+        '# :tada: Happy commit!',
+        `- Now pull request issue number reaches **777** (777). It's time to celebrate!`,
+        '',
+      ].join('\n'),
+    });
+  });
+
+  it('congratulates when pull request id is lucky', () => {
+    const context = {
+      commitIds: ['1243a86968b837366e6603cab1142462c8f33ea5'],
+      prNum: 2000,
+    };
+    const mb = new CustomMessageBuilder(
+      `# :tada: Happy commit!\n{{#messages}}- {{&.}}\n{{/messages}}`,
+      {}
+    );
+    const message = mb.build(context);
+    expect(message).toEqual({
+      lucky: true,
+      body: [
+        '# :tada: Happy commit!',
+        `- Now pull request issue number reaches **2000**. It's time to celebrate!`,
+        '',
+      ].join('\n'),
+    });
+  });
+
+  it('skips congratulatory message when it is not lucky', () => {
+    const context = {
+      commitIds: ['1243a86968b837366e6603cab1142462c8f33ea5'],
+      prNum: 410,
+    };
+    const mb = new CustomMessageBuilder(
+      `# :tada: Happy commit!\n{{#messages}}- {{&.}}\n{{/messages}}`,
+      {}
+    );
+    const message = mb.build(context);
+    expect(message).toEqual({
+      lucky: false,
+      body: '# :tada: Happy commit!\n',
+    });
+  });
 });

--- a/src/message_builder.ts
+++ b/src/message_builder.ts
@@ -58,7 +58,7 @@ class MessageBuilder {
 }
 
 const defaultRules = {
-  pr_reaches_power_of_10: true,
+  pr_reaches_contain_only_one_nonzero_digit: true,
   pr_reaches_power_of_2: true,
   pr_reaches_777: true,
   commit_hits_777: true,

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -43,19 +43,19 @@ export function parseRules(json: string): MessageForRuleSet {
 }
 
 export const Rules: NamedMessageForRuleSet = {
-  pr_reaches_power_of_10: {
+  pr_reaches_contain_only_one_nonzero_digit: {
     kind: 'pr',
-    rule: /(?:[1]0+)/,
+    rule: /(?:^[1-9]0+$)/,
     message: `Now pull request issue number reaches **{{prNum}}**. It's time to celebrate!`,
   },
   pr_reaches_power_of_2: {
     kind: 'pr',
-    rule: /(?:(512|1024|2048|4096|8192|16384|32768|65536))/,
+    rule: /(?:^(512|1024|2048|4096|8192|16384|32768|65536)$)/,
     message: `Now pull request issue number reaches **{{prNum}}** (power of 2). It's time to celebrate!`,
   },
   pr_reaches_777: {
     kind: 'pr',
-    rule: /(?:7{3,})/,
+    rule: /(?:^7{3,}$)/,
     message: `Now pull request issue number reaches **{{prNum}}** (777). It's time to celebrate!`,
   },
   commit_hits_777: {


### PR DESCRIPTION
- Fix for #15
- The regular expression pattern used in the rule of celebrating pull requests was not using `^` and `$`, so it was judged as "whether it is a multiple of 10".
- This also affected the judgment of "2 to the power of" and "777".
- This was fixed by using `^` and `$`.
- On the other hand, I felt that `2000` and `3000` should be celebrated, so I changed the criteria for celebration.
  - Use [A037124: Numbers that contain only one nonzero digit.](https://oeis.org/A037124) of 10 or more
