### PR TITLE
Set minimal permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
+name: Example
 on:
   - pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   example:

--- a/README.md
+++ b/README.md
@@ -22,9 +22,21 @@ c.f. https://github.com/kitsuyui/happy-commit/blob/main/src/rules.ts
 ## Example usage
 
 ```yaml
-      - name: happy-commit
-        uses: kitsuyui/happy-commit
-        continue-on-error: true
+name: happy-commit
+on:
+  - pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  happy:
+    runs-on: ubuntu-latest
+    name: happy
+    steps:
+      - uses: kitsuyui/happy-commit
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
If there is no setting at the Organization level, the default GitHub Actions will run with write-all permissions.
From a security perspective, it is desirable to explicitly set the minimum permissions.
