### PR TITLE
Update coverage badge to Octocov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # happy-commit
 
-[![codecov](https://codecov.io/gh/kitsuyui/happy-commit/branch/main/graph/badge.svg?token=FM7RYWGV0P)](https://codecov.io/gh/kitsuyui/happy-commit)
+![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/happy-commit/coverage.svg)
 
 - GitHub Action to celebrate your commits on PR.
 


### PR DESCRIPTION
## Summary
- Replace Codecov badge with Octocov coverage badge.
