### PR TITLE
Add gh-build-size reporting for action artifacts

### DIFF
--- a/.github/gh-build-size.yml
+++ b/.github/gh-build-size.yml
@@ -1,0 +1,32 @@
+version: 1
+publish:
+  enabled: true
+  branch: gh-build-size-assets
+comment:
+  key: action-build-size
+targets:
+  - id: total
+    label: Total action artifacts
+    files:
+      - dist/**
+    compressions: [raw, gzip, brotli]
+    badge:
+      compression: gzip
+      label: action artifacts (gzip)
+  - id: runtime
+    label: Runtime bundle
+    files:
+      - dist/**/*.mjs
+    compressions: [raw, gzip, brotli]
+  - id: sourcemaps
+    label: Source maps
+    files:
+      - dist/**/*.map
+    compressions: [raw, gzip, brotli]
+  - id: types
+    label: Type declarations
+    files:
+      - dist/**/*.d.ts
+      - dist/**/*.d.mts
+      - dist/**/*.d.cts
+    compressions: [raw, gzip, brotli]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -14,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -33,3 +38,8 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Measure build size
+        uses: kitsuyui/gh-build-size@v0.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Celebrate pull requests when their number or commit SHA matches a fun pattern.
 The repository also tracks `TODO` and `FIXME` markers with [`gh-counter`](https://github.com/kitsuyui/gh-counter).
+It also tracks built action artifact size with
+[`gh-build-size`](https://github.com/kitsuyui/gh-build-size).
 
 ## What it does
 


### PR DESCRIPTION
## Summary

- add `gh-build-size` configuration for the committed action `dist/` outputs
- run `gh-build-size@v0.1.2` after the build step in CI
- mention build size tracking in the README

## Verification

- `git diff --check`
