### PR TITLE
Use reusable actionlint and gh-counter workflows

### DIFF
--- a/.github/workflows/gh-counter.yml
+++ b/.github/workflows/gh-counter.yml
@@ -11,21 +11,4 @@ permissions:
 
 jobs:
   gh-counter:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Count maintenance comments
-        uses: kitsuyui/gh-counter@v1.2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload gh-counter output
-        uses: actions/upload-artifact@v4
-        with:
-          name: gh-counter-output
-          path: .gh-counter
-          include-hidden-files: true
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gh-counter.yml@main


### PR DESCRIPTION
## Summary
- Replace local actionlint and/or gh-counter job definitions with reusable workflow callers from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific workflow triggers and permissions unchanged.

## Changed files
- `.github/workflows/gh-counter.yml`

## Validation
- `actionlint -color=false <updated workflow files>`
- `git diff --check`
