### PR TITLE
Make test workflow failures blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Remove `continue-on-error` from the test workflow so lint, test, build, and build-size failures block the check.
- Keep the existing workflow triggers, permissions, and steps unchanged.

## Validation

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml ok"'\n- actionlint .github/workflows/test.yml\n- bun run lint\n- bun run test\n- bun run build && git diff --stat --exit-code -- dist\n\nNote: the build currently emits upstream dependency type export warnings from `ajv` / `fast-uri`, but it exits successfully and leaves `dist` unchanged.