### PR TITLE
fix: extract full match string to prevent capture group leaking into messages

### DIFF
--- a/src/message_builder.spec.ts
+++ b/src/message_builder.spec.ts
@@ -314,6 +314,26 @@ describe('MessageBuilder', () => {
     })
   })
 
+  it('shows only the full match string for commit_hits_same_numbers, not capture groups', () => {
+    const context = {
+      commitIds: ['aaaaa86968b837366e6603cab1142462c8f33ea5'],
+      prNum: 410,
+    }
+    const mb = new CustomMessageBuilder(
+      '# :tada: Happy commit!\n{{#messages}}- {{&.}}\n{{/messages}}',
+      {}
+    )
+    const message = mb.build(context)
+    expect(message).toEqual({
+      lucky: true,
+      body: [
+        '# :tada: Happy commit!',
+        '- Commit `aaaaa86968b837366e6603cab1142462c8f33ea5` is lucky! It contains **aaaaa**!.',
+        '',
+      ].join('\n'),
+    })
+  })
+
   it('appends additional rules before built-in rules', () => {
     const context = {
       commitIds: ['abcdef123'],

--- a/src/message_builder.ts
+++ b/src/message_builder.ts
@@ -61,7 +61,10 @@ class MessageBuilder {
       return null
     }
 
-    return Mustache.render(ruleConfig.message, { ...value, matched })
+    return Mustache.render(ruleConfig.message, {
+      ...value,
+      matched: matched[0],
+    })
   }
 
   private renderMessages<


### PR DESCRIPTION
## Why

The `commit_hits_same_numbers` rule uses the regex `/(?:([0-9a-f])\1{4,})/` which contains a capture group required for the backreference `\1`. `String.prototype.match()` returns `[fullMatch, capturedGroup, ...]` when the regex has capture groups, so passing the raw `RegExpMatchArray` to Mustache caused `Array.toString()` to join elements with a comma. For a commit SHA containing `aaaaa`, `{{matched}}` expanded to `"aaaaa,a"` instead of `"aaaaa"`.

## What changed

- `src/message_builder.ts`: pass `matched[0]` (the full match string) instead of the raw array to the Mustache render context
- `src/message_builder.spec.ts`: add a regression test asserting that a commit ID starting with five repeated hex digits renders the match as just `aaaaa`, not `aaaaa,a`

## Verification

All 40 tests pass. `biome check` reports no issues.

The capture group in `src/rules.ts:104` is intentionally kept — it is still required for `\1` to work. Only the downstream consumer (`message_builder.ts`) was changed to discard the captured sub-match.
