### PR TITLE
feat: expose lucky output from action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Celebrate built-in rules only when their expected occurrences at the current repository size stay below this value'
     required: false
 
+outputs:
+  lucky:
+    description: "'true' if a lucky commit or PR number was found, 'false' otherwise"
+
 runs:
   # https://json.schemastore.org/github-action.json
   # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ async function run() {
       repositoryCommitCount,
       maxExpectedOccurrences,
     })
+    core.setOutput('lucky', String(message.lucky))
     await updateMessage(octokit, prNum, userLogin, message)
   } catch (error) {
     core.setFailed(`Unexpected error: ${formatUnexpectedError(error)}`)


### PR DESCRIPTION
## Summary

Expose the `lucky` boolean as an action output so downstream workflow steps can branch on whether a lucky commit or PR number was found.

- `action.yml`: declare `outputs.lucky` with description
- `src/index.ts`: call `core.setOutput('lucky', ...)` after building the message

## Motivation

Previously, callers had to parse PR comments to determine if the action found a lucky commit. With this output, downstream steps can use `steps.<id>.outputs.lucky` directly.

## Test plan

- [ ] Existing tests pass (`bun run test`)
- [ ] Build succeeds (`bun run build`)
- [ ] Lint passes (`bun run lint`)
