### PR TITLE
ci: pin workflow action refs to commit SHA and tighten permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: dogfooding
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,22 @@ on:
     branches:
       - main
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
       - name: Install dependencies
@@ -42,6 +42,6 @@ jobs:
         run: git diff --exit-code -- dist
 
       - name: Measure build size
-        uses: kitsuyui/gh-build-size@v0.1.2
+        uses: kitsuyui/gh-build-size@97ad8d5f4fff8ba676a5c614822adacab32780e3 # v0.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `test.yml` and `main.yml` to commit SHA
- Reduce `permissions.contents` from `write` to `read` in `test.yml`

`test.yml` referenced `actions/checkout@v6`, `oven-sh/setup-bun@v2`, `actions/setup-node@v6`, and `kitsuyui/gh-build-size@v0.1.2` using only version tags. `main.yml` referenced `actions/checkout@v6` similarly. Tags can be force-pushed by the repository owner at any time, creating a supply-chain risk.

`octocov.yml` already pinned all its actions to SHA in previous PRs (#823, #824); this change applies the same pattern to the remaining workflows.

The `contents: write` permission in `test.yml` was excess — the workflow only reads source, runs lint/test/build, and measures build size; none of these require write access to repo contents.

## Validation

- `bun run lint` (biome check) — no issues
- `bun run test` — 47/47 tests pass
- `madge --circular --extensions ts src/` — no circular dependencies

## Notes

SHAs match those already used in `octocov.yml`:
- `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6)
- `oven-sh/setup-bun` → `0c5077e51419868618aeaa5fe8019c62421857d6` (v2)
- `actions/setup-node` → `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6)
- `kitsuyui/gh-build-size` → `97ad8d5f4fff8ba676a5c614822adacab32780e3` (v0.1.2)