### PR TITLE
ci: verify schema.json is up to date in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Verify dist is up to date
         run: git diff --exit-code -- dist
 
+      - name: Verify schema.json is up to date
+        run: |
+          bun run generate-json-schema
+          bun run format
+          git diff --exit-code -- schema.json
+
       - name: Measure build size
         uses: kitsuyui/gh-build-size@v0.1.2
         with:


### PR DESCRIPTION
## Summary

Adds a CI step to detect when `schema.json` drifts from the TypeScript types it is generated from.

**Problem**: `schema.json` (the external schema consumed by IDE tooling and JSON linters) and the inline AJV schema in `src/validate.ts` were managed independently. CI ran lint, test, and build — but never re-ran `generate-json-schema`. A change to `RuleStringPattern` in `src/interfaces.ts` could leave `schema.json` stale without any CI signal.

**Fix**: After the build step, re-run `generate-json-schema` and `biome format`, then assert no diff in `schema.json`. If the committed file is out of date, the step fails and the author must update it.

## Changes

- `.github/workflows/test.yml`: add `Verify schema.json is up to date` step after `Verify dist is up to date`

## Verification

The new step was validated locally:
```
bun run generate-json-schema
bun run format
git diff --exit-code -- schema.json   # exits 0 (no diff)
```

## Trade-offs

- `bun run format` runs Biome on all files after schema regeneration, not just `schema.json`. This is acceptable because the formatter is deterministic — a clean working tree remains clean after formatting.
- The root dual-management (inline schema in `validate.ts` vs `schema.json`) is preserved. Eliminating it would require `resolveJsonModule: true` in tsconfig and further changes; this CI check provides detection with minimal scope.
