### PR TITLE
docs: document Mustache template variables for custom rule messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ You can add your own rules with `additional-rules`. The value is a JSON array, a
 | `rule` | Yes | Regular expression pattern evaluated against the PR number or commit SHA |
 | `message` | Yes | Mustache template rendered into the comment when the rule matches |
 
+### Template variables
+
+The following Mustache variables are available in `message`, depending on `kind`:
+
+| Variable | Available when | Description |
+| --- | --- | --- |
+| `{{prNum}}` | `kind: "pr"` | Pull request number as a string |
+| `{{commitId}}` | `kind: "commit"` | Commit SHA |
+| `{{matched}}` | both | First capture of `rule` matched against the target value |
+
 For example, this rule celebrates any commit SHA containing `1`.
 
 ```yaml


### PR DESCRIPTION
Custom rules can use Mustache variables in their `message` field, but the README
only showed the variables implicitly in the sample code (`{{commitId}}`, `{{matched}}`).
Users had to read source code to discover all available variables or to understand that
`kind: "pr"` and `kind: "commit"` expose different variable sets.

## Changes

- **`README.md`** — add a "Template variables" subsection under "Custom rules" with a
  reference table listing `{{prNum}}` (pr), `{{commitId}}` (commit), and `{{matched}}`
  (both) with their availability and description.

## Verification

- `typos README.md` — no spelling issues
- README-only change; action logic is unaffected
