### PR TITLE
fix: exclude spec files from codeToTestRatio code glob

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -5,6 +5,7 @@ coverage:
 codeToTestRatio:
   code:
     - "src/**/*.ts"
+    - "!src/**/*.spec.ts"
   test:
     - "src/**/*.spec.ts"
 testExecutionTime:


### PR DESCRIPTION
The `codeToTestRatio.code` glob `src/**/*.ts` matched spec files
(`*.spec.ts`), causing them to be counted in both the code and test sets.
This inflated the denominator (code line count) and produced a lower
ratio than the actual production-to-test ratio.

Add `!src/**/*.spec.ts` as an exclusion pattern so the code side counts
only production TypeScript files. The test side is unchanged.

This follows the same pattern used in octocov's own configuration for
excluding Go test files from the code set.
