### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ jobs:
 
 This repository keeps a local example workflow in `.github/workflows/main.yml`. It uses `pull_request` and `uses: ./` so changes in the current branch are tested before release. That pattern should stay limited to the action repository itself, because a local action from an untrusted fork must not run with `pull_request_target`.
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and run:
+
+```sh
+lefthook install
+```
+
+This sets up the following Git hooks:
+
+- **pre-commit**: runs `bun run lint` (Biome checks) — fast static feedback before each commit.
+- **pre-push**: runs `bun run lint` and `bun run test` — full local validation before pushing.
+
+CI still runs the complete suite on every pull request and push to main; the hooks bring that feedback earlier in your workflow.
+
 ## License
 
 MIT

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+
+pre-push:
+  jobs:
+    - name: lint
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run lint
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; bun run test


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to mirror the CI lint and test checks as local Git hooks
- Add a `## Development` section to `README.md` documenting how to install and use the hooks
- CI workflow files are not modified

## What the hooks do

- **pre-commit**: runs `bun run lint` (Biome static checks) for fast feedback before each commit
- **pre-push**: runs `bun run lint` and `bun run test` so the full local suite passes before pushing

CI still runs the complete suite on every pull request and push to main; the hooks surface failures earlier in the development workflow.

## Files changed

- `lefthook.yml` (new)
- `README.md` (Development section added before License)
