### PR TITLE
docs: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a problem with the happy-commit action
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of the problem.
+
+**Action version / ref**
+e.g. `kitsuyui/happy-commit@v1.2.3` or a specific commit SHA.
+
+**Workflow configuration**
+```yaml
+# Paste the relevant steps from your workflow here.
+```
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior / error output**
+```
+Paste the relevant error output or logs here.
+```
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an improvement to the happy-commit action
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem or motivation**
+A clear and concise description of the problem this feature would solve.
+
+**Proposed solution**
+Describe what you would like to happen.
+
+**Alternatives considered**
+Describe any alternative solutions or features you have considered.
+
+**Additional context**
+Add any other context here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- Describe what this PR changes and why. -->
+
+## Changes
+
+- 
+
+## Checklist
+
+- [ ] `bun run lint` passes
+- [ ] `bun run test` passes
+- [ ] `bun run build` compiles without errors
+- [ ] Tests added or updated where applicable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thank you for considering contributing to happy-commit.
+
+## Development setup
+
+```console
+bun install --frozen-lockfile
+```
+
+## Making changes
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your changes and add tests where applicable.
+3. Run the checks before opening a PR:
+
+   ```console
+   bun run lint
+   bun run test
+   bun run build
+   ```
+
+4. Open a pull request against `main` and fill out the PR template.
+
+## Code style
+
+This project uses [Biome](https://biomejs.dev/) for formatting and linting.
+Run `bun run format` to auto-format your changes.
+
+## Reporting issues
+
+Use the GitHub issue tracker. For security vulnerabilities, see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues.
+
+Instead, open a [GitHub Security Advisory](https://github.com/kitsuyui/happy-commit/security/advisories/new) or contact the maintainer directly through GitHub.
+
+We aim to acknowledge receipt within 5 business days and to provide a fix or mitigation plan within 30 days, depending on severity.
+
+## Scope
+
+This is a GitHub Action that:
+
+- Accepts `GITHUB_TOKEN` as a required input
+- Posts comments and reactions to pull requests
+
+Security concerns in scope include:
+- Unintended token scope usage or credential leakage
+- Logic that allows unintended write access to repositories
+- Vulnerabilities in runtime dependencies (`node_modules`)
+
+Please include the dependency name and version in your report if the issue originates from a dependency.


### PR DESCRIPTION
## Summary

Add missing community health files to make contributing and security reporting explicit.

## Changes

- `CONTRIBUTING.md`: documents how to set up the project (`bun install`), the required checks before a PR (`lint`, `test`, `build`), and the code style tool (Biome)
- `SECURITY.md`: security policy with a private vulnerability disclosure path via GitHub Security Advisories; scope covers token usage, unintended write access, and dependency vulnerabilities
- `.github/ISSUE_TEMPLATE/bug_report.md`: structured bug report template for action issues
- `.github/ISSUE_TEMPLATE/feature_request.md`: feature request template
- `.github/PULL_REQUEST_TEMPLATE.md`: PR checklist for lint, test, build, and test coverage

## Motivation

The repository lacked any community health files, leaving contributors without guidance on the development process and security disclosure path. This adds the minimum set to address those gaps.

## Verification

All added files are Markdown only. No source code, workflow logic, or `action.yml` was changed.