### PR TITLE
fix: pin external references to SHA for supply chain observability

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>kitsuyui/renovate-config"
+    "local>kitsuyui/renovate-config#cdad3c71e34e5abadf909c996906011bbc2b5725"
   ]
 }

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@8019e658f4665c962d0a88eb38b3b6be418e7be8


### PR DESCRIPTION
## Summary

Pin two mutable external references to specific commit SHAs to improve supply chain observability.

### Changes

**`.github/renovate.json5`** — pin Renovate preset to SHA:
```diff
- "local>kitsuyui/renovate-config"
+ "local>kitsuyui/renovate-config#cdad3c71e34e5abadf909c996906011bbc2b5725"
```

**`.github/workflows/spellcheck.yml`** — pin reusable workflow to SHA:
```diff
- uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+ uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@8019e658f4665c962d0a88eb38b3b6be418e7be8
```

## Why

Without pinning, changes to `kitsuyui/renovate-config` and `kitsuyui/gh-actions-workflows` are silently reflected in this repo's Renovate behaviour and CI on every run — with no trace in this repo's commit history.

`gh-counter.yml` and `gitignore-in.yml` already use SHA-pinned references; this PR brings `renovate.json5` and `spellcheck.yml` into alignment.

## Verification

- `bun run lint`: clean (biome check passes)
- No functional changes to CI logic or Renovate rules
