### PR TITLE
ci: run independent test checks in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
+      - parallel:
+          - name: Lint
+            run: bun run lint
 
-      - name: Test
-        run: bun run test
+          - name: Test
+            run: bun run test
 
-      - name: Build
-        run: bun run build
+          - name: Build
+            run: bun run build
 
       - name: Verify dist is up to date
         run: git diff --exit-code -- dist


### PR DESCRIPTION
## Summary

- Run the independent lint, test, and build checks in `.github/workflows/test.yml` with GitHub Actions step-level `parallel` execution.
- Keep dist verification, schema verification, and build-size reporting sequential after the build completes.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml ok"'`
- `biome check ./` via the pre-commit hook
- `vitest run --coverage` via the pre-push hook

## Notes

- Local `actionlint 1.7.12` does not recognize the new `parallel` step syntax yet and reports that the step is missing `run` or `uses`.
