### PR TITLE
ci: run octocov checks in parallel

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -26,14 +26,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
+      - parallel:
+          - name: Lint
+            run: bun run lint
 
-      - name: Test
-        run: bun run test
+          - name: Test
+            run: bun run test
 
-      - name: Build
-        run: bun run build
+          - name: Build
+            run: bun run build
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov


### PR DESCRIPTION
## Summary

- Run independent lint, test, and build checks in `.github/workflows/octocov.yml` with GitHub Actions step-level `parallel` execution.
- Keep octocov reporting sequential after the coverage-producing test step completes.

## Validation

- Parsed `.github/workflows/octocov.yml` as YAML.
- `bun run lint`
- `bun run test`

## Notes

- Local `actionlint 1.7.12` does not recognize the new `parallel` step syntax yet.
